### PR TITLE
evidence(vestige): source-level re-verification at a pinned commit (8 up, 4 down)

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -137,7 +137,7 @@
 | Memora | 433 | Python | MIT | — | 2025-11-11 | 27% |
 | TeleMem | 461 | Python | MIT | — | 2026-05 | 7% |
 | Octopoda-OS | 536 | Python | MIT | — | 2026-04-02 | 15% |
-| vestige | 588 | Rust | AGPL-3.0 | ✅ | 2026-01-25 | 42% |
+| vestige | 588 | Rust | AGPL-3.0 | ✅ | 2026-01-25 | 47% |
 | memoir | 594 | Python | Apache-2.0 | — | 2025-08 | 18% |
 | context-infra | 672 | Python | MIT | — | 2026-03-16 | 23% |
 | MemoMind | 697 | Python | ? | — | 2026-03-15 | 23% |
@@ -401,7 +401,7 @@
 | Memora | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 4 | 1 |
 | TeleMem | — | ✅ | — | — | — | — | — | — | 1 | 1 |
 | Octopoda-OS | — | ✅ | — | — | — | — | — | — | 3 | 1 |
-| vestige | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 8 | 3 |
+| vestige | ✅ | ✅ | ✅ | — | — | — | ✅ | ✅ | 7 | 3 |
 | memoir | ✅ | — | — | — | — | — | — | ✅ | 2 | 1 |
 | context-infra | ✅ | ✅ | — | — | — | — | — | — | 2 | 1 |
 | MemoMind | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 2 | 3 |
@@ -577,7 +577,7 @@
 | Memora | — | ✅ | ✅ | — | — | — | — | — |
 | TeleMem | ✅ | — | ✅ | — | — | — | — | — |
 | Octopoda-OS | ✅ | — | ✅ | — | — | — | — | — |
-| vestige | — | — | ✅ | — | — | — | — | — |
+| vestige | — | — | ✅ | ✅ | — | ✅ | — | — |
 | memoir | ✅ | — | — | — | — | — | — | — |
 | context-infra | ✅ | ✅ | — | ✅ | ✅ | — | ✅ | ✅ |
 | MemoMind | ✅ | — | ✅ | ✅ | — | — | — | — |

--- a/comparison.md
+++ b/comparison.md
@@ -137,7 +137,7 @@
 | Memora | 433 | Python | MIT | — | 2025-11-11 | 27% |
 | TeleMem | 461 | Python | MIT | — | 2026-05 | 7% |
 | Octopoda-OS | 536 | Python | MIT | — | 2026-04-02 | 15% |
-| vestige | 588 | Rust | AGPL-3.0 | ✅ | 2026-01-25 | 35% |
+| vestige | 588 | Rust | AGPL-3.0 | ✅ | 2026-01-25 | 42% |
 | memoir | 594 | Python | Apache-2.0 | — | 2025-08 | 18% |
 | context-infra | 672 | Python | MIT | — | 2026-03-16 | 23% |
 | MemoMind | 697 | Python | ? | — | 2026-03-15 | 23% |
@@ -225,7 +225,7 @@
 | Memora | MCP server | SQLite+FTS5 | MCP | — | ✅ | ✅ | ✅ | 2 | — | — | — | — | ✅ | — | pip install | free |
 | TeleMem | Library | Vector DB | SDK | — | — | ✅ | — | 1 | — | — | — | — | — | — | pip install | free |
 | Octopoda-OS | Local server | Key-value store | MCP | — | ✅ | ✅ | — | 1 | — | — | — | — | — | ✅ | pip install | free |
-| vestige | Local binary (22MB) | SQLite+FTS5 | MCP | — | ✅ | ✅ | — | 1 | — | — | — | — | ✅ | — | cargo install | free |
+| vestige | Local binary (22MB) | SQLite+FTS5 | MCP | — | ✅ | ✅ | — | 1 | ✅ | — | — | ✅ | ✅ | ✅ | cargo install | free |
 | memoir | Plugin (Claude Code, Codex) | Hierarchical paths | Plugin+CLI | — | ✅ | ✅ | — | 1 | — | — | — | — | — | — | pip install | free |
 | context-infra | Local Python | Markdown files | MCP | — | — | ✅ | — | 1 | ✅ | — | — | — | — | — | setup_guide.md | free |
 | MemoMind | Local Python | Local vector DB | MCP | — | ✅ | ✅ | — | 1 | — | — | — | — | — | — | pip install | free |
@@ -313,7 +313,7 @@
 | Memora | Memory entry (hierarchical) | — | — | ✅ | — | — | — | — | — | — | — | — | — | — | — | 8 |
 | TeleMem | Memory entry | — | — | — | — | — | — | — | — | — | — | — | — | — | — | 7 |
 | Octopoda-OS | Memory entry | — | — | — | — | — | — | — | — | — | — | — | — | — | — | 5 |
-| vestige | Cognitive memory unit | ✅ | — | ✅ | — | — | — | — | — | — | — | — | — | — | — | 5 |
+| vestige | Cognitive memory unit | — | — | ✅ | — | ✅ | — | — | — | — | — | — | ✅ | — | — | 27 |
 | memoir | Hierarchical memory node | ✅ | — | — | — | — | — | — | — | — | — | — | — | ✅ | ✅ | 5 |
 | context-infra | Context entry | — | — | — | — | — | — | — | — | — | — | — | — | ✅ | — | 4 |
 | MemoMind | Memory entry | ✅ | — | ✅ | — | — | — | — | — | — | — | — | — | — | — | 6 |
@@ -401,7 +401,7 @@
 | Memora | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 4 | 1 |
 | TeleMem | — | ✅ | — | — | — | — | — | — | 1 | 1 |
 | Octopoda-OS | — | ✅ | — | — | — | — | — | — | 3 | 1 |
-| vestige | ✅ | ✅ | ✅ | ✅ | — | — | — | ✅ | 4 | 1 |
+| vestige | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 8 | 3 |
 | memoir | ✅ | — | — | — | — | — | — | ✅ | 2 | 1 |
 | context-infra | ✅ | ✅ | — | — | — | — | — | — | 2 | 1 |
 | MemoMind | ✅ | ✅ | ✅ | — | — | — | — | ✅ | 2 | 3 |
@@ -489,7 +489,7 @@
 | Memora | — | ✅ | ✅ | — | — | — | ✅ |
 | TeleMem | — | — | — | — | — | — | — |
 | Octopoda-OS | — | — | — | — | — | — | ✅ |
-| vestige | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
+| vestige | ✅ | ✅ | ✅ | — | — | — | ✅ |
 | memoir | — | ✅ | — | — | — | — | — |
 | context-infra | — | — | — | — | — | — | — |
 | MemoMind | — | ✅ | — | — | — | — | ✅ |
@@ -577,7 +577,7 @@
 | Memora | — | ✅ | ✅ | — | — | — | — | — |
 | TeleMem | ✅ | — | ✅ | — | — | — | — | — |
 | Octopoda-OS | ✅ | — | ✅ | — | — | — | — | — |
-| vestige | ✅ | — | ✅ | — | — | — | — | — |
+| vestige | — | — | ✅ | — | — | — | — | — |
 | memoir | ✅ | — | — | — | — | — | — | — |
 | context-infra | ✅ | ✅ | — | ✅ | ✅ | — | ✅ | ✅ |
 | MemoMind | ✅ | — | ✅ | ✅ | — | — | — | — |
@@ -665,7 +665,7 @@
 | Memora | ✅ | ✅ | — | — | — | — | — | — | — | — | — |
 | TeleMem | — | — | — | — | — | — | — | — | — | — | — |
 | Octopoda-OS | ✅ | — | — | — | — | — | — | ✅ | — | — | — |
-| vestige | ✅ | ✅ | — | — | — | — | ✅ | — | — | — | — |
+| vestige | ✅ | ✅ | ✅ | — | — | ✅ | ✅ | — | — | — | — |
 | memoir | ✅ | ✅ | — | — | — | — | — | — | — | — | — |
 | context-infra | ✅ | — | ✅ | — | — | ✅ | — | — | — | — | — |
 | MemoMind | ✅ | — | — | — | — | — | — | — | — | — | — |
@@ -753,7 +753,7 @@
 | Memora | — | — | — | — | — |
 | TeleMem | — | — | — | — | — |
 | Octopoda-OS | — | — | — | — | — |
-| vestige | — | — | — | — | — |
+| vestige | — | — | — | — | ✅ |
 | memoir | — | — | — | — | — |
 | context-infra | — | — | — | — | — |
 | MemoMind | — | — | — | — | — |

--- a/evidence/vestige.md
+++ b/evidence/vestige.md
@@ -1,118 +1,321 @@
-# Vestige Audit
+# Vestige — Evidence
 
-**Date:** 2026-05-28
-**Source:** https://github.com/samvallad33/vestige
-**Version:** v2.1.23 (latest as of audit)
+**Repo:** `github.com/samvallad33/vestige`
+**Stars:** 592
 **Language:** Rust
-**Stars:** 540
 **License:** AGPL-3.0
+**Created:** 2026-01-25
+**Description:** Local-first cognitive memory for AI agents — FSRS-6 decay, prediction-error-gated ingest, MCP-native, single Rust binary with an embedded dashboard.
 
-## URL Correction
+> **All citations pin to commit [`54f69b3`](https://github.com/samvallad33/vestige/tree/54f69b369ec478aefddfc72093bf06d0fc9d21a3)** (`origin/main`, v2.3.0, 2026-07-26) so line numbers stay valid permanently.
+>
+> This file updates the 2026-05-28 audit of Vestige at v2.1.23. That audit was explicit that it worked from the README — it wrote *"the following features are genuinely not mentioned anywhere in the README"* and titled its inventory *"Feature Inventory (from README)."* It was accurate and fair on that basis, and it corrected eleven cells in Vestige's favour unprompted plus a repo URL that pointed at a 404. Since `CONTRIBUTING.md` states *"Code beats docs,"* this pass re-checks every feature against source at a pinned commit.
+>
+> **Four cells currently marked ✅ are corrected DOWN to ❌ here** (`entities`, `deep`, `trustModel`, `autoExtract`). They did not survive their own definitions. They are listed with the same evidence standard as the upgrades.
 
-The claimed URL `https://github.com/nicholasgriffintn/vestige` returns **404** — the repository does not exist at that path and never redirected. The actual repository is `https://github.com/samvallad33/vestige`.
+---
 
-## Summary
+## System Metadata
 
-Vestige is a Rust-based "cognitive memory for AI agents" exposed as an MCP server. It implements neuroscience-inspired primitives (FSRS-6 spaced repetition, prediction error gating, synaptic tagging, spreading activation, memory dreaming). Runs as a single ~20MB binary with an optional SvelteKit + Three.js 3D dashboard on localhost:3927. 25 MCP tools across core memory, cognitive engine, autonomic, scoring/dedup, maintenance, deep reference, and active forgetting categories.
-
-## Claim Audit
-
-### Verified Claims
-
-| Claim | Status | Evidence |
-|-------|--------|----------|
-| offline | ✅ Verified | "100% local. Zero cloud."; "First run downloads embedding model (~130MB), then fully offline" |
-| privacy | ✅ Verified | "your data never leaves your machine" |
-| keywords | ✅ Verified | `search` tool: "Concrete literal search for exact identifiers"; keyword-mode search |
-| timeline | ✅ Verified | `memory_timeline`: "Browse chronologically, grouped by day"; `memory_changelog`: "Audit trail of state transitions" |
-| p_claude | ✅ Verified | "Works Everywhere" table lists Claude Code integration |
-| p_codex | ✅ Verified | "Works Everywhere" table lists Codex integration |
-| p_windsurf | ✅ Verified | "Works Everywhere" table lists Windsurf integration |
-
-### Partially Verified
-
-| Claim | Issue | Evidence |
-|-------|-------|----------|
-| entities | Not a named feature; memories exist as graph nodes with connections via spreading activation. No dedicated "entity" metadata tagging. | Knowledge graph with node-edge structure. No entity-type annotation on memories. |
-| autoExtract | Not called "autoExtract." The `smart_ingest` tool performs prediction error gating (CREATE/UPDATE/SUPERSEDE) which is a form of automatic extraction/classification, but is triggered by tool call, not automatic background extraction. | `smart_ingest`: "Intelligent storage with CREATE/UPDATE/SUPERSEDE via Prediction Error Gating" |
-| searchModes=4 | Cannot confirm exactly 4. The `search` tool has concrete/literal, keyword, semantic (HyDE), reranking, temporal, competition, spreading activation — at least 7 stages. These are not presented as discrete "modes" numbered as 4. | "Concrete literal search for exact identifiers, or 7-stage cognitive search" |
-
-### Unverified (not enough data)
-
-| Claim | Issue |
+| Field | Value |
 |-------|-------|
-| schemaFields=5 | README does not describe DB schema structure or field count. Mentions SQLite + FTS5 + USearch HNSW vector store, but no schema enumeration. |
+| **Deployment** | `Local binary (22MB)` |
+| **Storage** | `SQLite + FTS5 + USearch HNSW` |
+| **Integration** | `MCP` |
+| **Single binary?** | `yes` |
+| **Setup** | `cargo install` / `npx @vestige/init` |
+| **Pricing** | `free` |
+| **Storage unit** | `Cognitive memory unit` |
 
-### Corrections — Claimed Absent, Actually Present
+---
 
-| Feature | User Claim | Reality |
-|---------|-----------|---------|
-| **webUi** | absent | **Present.** Full SvelteKit + Three.js 3D dashboard (`vestige dashboard` on localhost:3927/Dashboard) with WebSocket real-time events, memory birth animations, retention curves. Heavily marketed. |
-| **fulltext** | false | **Present.** SQLite FTS5 explicitly listed in architecture: "SQLite + FTS5 · USearch HNSW · Nomic Embed v1.5" |
-| **semantic** | absent | **Present.** 7-stage cognitive search includes "semantic" + HyDE query expansion: "Template-based Hypothetical Document Embeddings" |
-| **hybrid** | absent | **Present.** "7-stage cognitive search — HyDE expansion + keyword + semantic + reranking + temporal + competition + spreading activation" |
-| **deep** | absent | **Present.** `deep_reference` tool: "8-stage pipeline: FSRS-6 trust scoring, intent classification, spreading activation, temporal supersession, contradiction analysis, relation assessment, dream insight integration, reasoning chain generation" |
-| **decay** | absent | **Present.** FSRS-6 spaced repetition: "21 parameters governing the mathematics of forgetting." Central marketing pillar. |
-| **supersede** | absent | **Present.** `smart_ingest` explicitly supports SUPERSEDE mode. "When new information arrives, Vestige compares it against existing memories. Redundant? Merged. Contradictory? Superseded." |
-| **contradiction** | absent | **Present.** `contradictions` MCP tool: "Honest memory inspection. Scans a topic or recent memories for trust-weighted disagreements." v2.1.2 added "First-class contradiction inspection." |
-| **trustModel** | absent | **Present.** FSRS-6 trust scoring in `deep_reference` pipeline; "trust-weighted disagreements" in contradictions tool. |
-| **explicitForget** | absent | **Present.** Two distinct forgetting mechanisms: `suppress` (reversible 24h inhibition, Anderson 2025 SIF) and `purge` (irreversible, permanent deletion). Both are intentional, user-triggered. |
-| **dedup** | absent | **Present.** `find_duplicates`: "Detect and merge redundant memories via cosine similarity." Also prediction error gating auto-merges during ingest. |
+## Architecture
 
-### Confirmed Absent
+### Proxy ❌
+> Intercepts and modifies the LLM conversation stream in-flight.
 
-The following features are genuinely not mentioned anywhere in the README:
+Integration is MCP stdio + Streamable HTTP + shell hooks — all excluded by the definition.
 
-multiAgent, actions, anticipatedQueries, triggerRules, domainTag, taskType, context (as category), source (as metadata field), originTrust, emotional, conflict (as explicit module, though contradictions related), layeredMemory, timeTravel, codeGraph (has knowledge graph, not code graph), docsSearch, factQuery, quarantine, autoResolve, contentPreproc, qualityRefine, narrative, clustering, recurrence, persona.
+### Web/TUI ✅
+- [`crates/vestige-mcp/src/dashboard/static_files.rs:14`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/dashboard/static_files.rs#L14) — `include_dir!("$CARGO_MANIFEST_DIR/../../apps/dashboard/build")` embeds the compiled SvelteKit app into the binary
+- [`crates/vestige-mcp/src/bin/cli.rs:221`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/bin/cli.rs#L221) — `vestige dashboard` serves it on 127.0.0.1:3927
 
-### Special: fulltext=false but keywords=true
+### Offline ✅
+- [`crates/vestige-core/Cargo.toml:14`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/Cargo.toml#L14) — `reqwest` is `optional = true`, pulled in only by the non-default `connectors`/`cloud-sync` features; a default build links no HTTP client
+- [`crates/vestige-core/src/embeddings/local.rs:17`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/embeddings/local.rs#L17) — local ONNX embeddings after a one-time model download
 
-User flagged this as an unusual combination. Confirmed: **fulltext IS present** via SQLite FTS5. The `search` tool has both concrete/keyword matching and semantic search. The claim of "fulltext=false, keywords=true" is contradicted by the README.
+### Multi-agent ❌
+Multiple MCP clients can share one `--data-dir`, but there is no agent identity (`git grep agent_id` returns nothing), no agent directory, and no inter-agent messaging. Not claimed.
 
-## Feature Inventory (from README)
+### LLM providers (count: 1) ✅
+- [`crates/vestige-core/src/embeddings/local.rs:47`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/embeddings/local.rs#L47) — one provider (fastembed). Two selectable models run on the same runtime; the second is behind a non-default cargo feature. Count stays 1.
 
-### MCP Tools (25)
-`session_context`, `search`, `smart_ingest`, `memory`, `codebase`, `intention`, `dream`, `explore_connections`, `predict`, `memory_health`, `memory_graph`, `importance_score`, `find_duplicates`, `system_status`, `consolidate`, `memory_timeline`, `memory_changelog`, `backup`, `export`, `gc`, `restore`, `deep_reference`, `cross_reference`, `contradictions`, `suppress`
+### Cache optimization ✅ ← **was ❌**
+- [`crates/vestige-core/src/storage/sqlite.rs:318`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L318) — `query_cache: Option<Mutex<LruCache<String, Vec<f32>>>>`
+- [`crates/vestige-core/src/storage/sqlite.rs:2843`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L2843) — `get_query_embedding()` returns the cached vector on hit, `cache.put(...)` on miss, so repeated queries skip re-embedding
+- [`crates/vestige-core/Cargo.toml:156`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/Cargo.toml#L156) — dependency declared under the comment "LRU cache for query embeddings"
 
-### Cognitive Modules (30)
-17 neuroscience, 11 advanced, 2 search — covering prediction error gating, FSRS-6, HyDE expansion, synaptic tagging, spreading activation, dual-strength model, memory dreaming, waking SWR tagging, autonomic regulation, active forgetting (suppression-induced forgetting + Rac1 cascade).
+### Procedural memory ❌
+`MemorySystem::Procedural` ([`memory/mod.rs:81`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/memory/mod.rs#L81)) is a memory-type classification. Nothing loads, interprets, or executes stored content. The definition requires execution at retrieval time. Not claimed.
 
-### Platform Support
-macOS ARM + Intel, Linux x86_64, Windows x86_64. MCP stdio transport. Optional HTTP MCP (`--http`).
+### Sandboxed execution ❌
+`git grep -i sandbox` over `crates/` returns zero hits.
 
-### Optional Features
-- Qwen3 0.6B embeddings (Candle backend, Metal on Apple Silicon)
-- CUDA/cuDNN for NVIDIA GPU acceleration
-- SANHEDRIN verifier (off by default, OpenAI-compatible endpoint required)
-- SQLCipher encryption
-- Cognitive Sandwich Claude Code hooks (opt-in)
+### Scheduled/autonomous ✅ ← **was ❌**
+- [`crates/vestige-mcp/src/main.rs:451`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/main.rs#L451) — `autopilot::spawn(...)` runs at server startup, opt-*out* via `VESTIGE_AUTOPILOT_ENABLED=0`
+- [`crates/vestige-mcp/src/autopilot.rs:461`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/autopilot.rs#L461) — `tokio::time::interval(Duration::from_secs(60))` poller
+- [`crates/vestige-mcp/src/autopilot.rs:343`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/autopilot.rs#L343) — autonomously calls `storage.promote_memory()` when `composite_score > 0.85`, with no user prompt
+- [`crates/vestige-core/src/storage/sqlite.rs:3633`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L3633) — unattended consolidation cycle every 6h (`VESTIGE_CONSOLIDATION_INTERVAL_HOURS`)
 
-### Dashboard
-SvelteKit 2 + Svelte 5 + Three.js + Tailwind CSS 4 + WebSocket. 3D force-directed graph, bloom post-processing, memory birth animations, FSRS retention curves, command palette, PWA installable. 16 left-nav pages.
+*Disclosure:* two autonomous behaviours are env-gated but default **on** — `VESTIGE_AUTO_CONSOLIDATE_MERGE` and `VESTIGE_BACKFILL_AUTOFIRE`.
 
-## Architecture Notes
+### Privacy/encrypt ✅
+- [`crates/vestige-core/src/storage/sqlite.rs:468`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L468) — SQLCipher at rest via `conn.pragma_update(None, "key", ...)`
+- [`crates/vestige-core/src/storage/cloud_crypto.rs:35`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/cloud_crypto.rs#L35) — Argon2id + XChaCha20-Poly1305 envelope applied client-side before any upload
 
-- Monorepo: Rust core/MCP/e2e + SvelteKit dashboard + hook coverage
-- ~80,000 lines of Rust
-- Single binary deployment (~20MB compressed)
-- Embedding: Nomic Embed Text v1.5 (768d -> 256d Matryoshka, 8192 context) — downloaded on first run (~130MB)
-- Vector search: USearch HNSW
-- Reranker: Jina Reranker v1 Turbo (38M params)
-- Backend events: 20-event WebSocket bus powering real-time dashboard updates
-- Autopilot: background tasks for event routing, duplicate detection, supervisor loop with panic recovery
+### Data export ✅ ← **was ❌**
+- [`crates/vestige-mcp/src/bin/cli.rs:158`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/bin/cli.rs#L158) — `vestige export <output> --format json|jsonl [--tags ...] [--since ...]` clap subcommand
+- [`crates/vestige-mcp/src/bin/cli.rs:2075`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/bin/cli.rs#L2075) — `run_export()` implementation
+- [`crates/vestige-core/src/storage/sqlite.rs:6414`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L6414) — second path, `export_portable_archive()` (ID/FSRS/edge-preserving JSON)
 
-## Notable Design Decisions
+---
 
-1. **Neuroscience-first branding.** Every feature is anchored to a real cognitive science paper (Bjork & Bjork 1992, Buzsaki 2015, Anderson 2025, etc.). The "active forgetting" primitive is explicitly distinguished from passive decay.
+## Data Model
 
-2. **Agent-neutral, MCP-native.** Default transport is stdio MCP. Any MCP client can use it. HTTP transport is opt-in.
+### Entities ❌ ← **was ✅ (corrected down)**
+- [`crates/vestige-core/src/advanced/retroactive_backfill.rs:117`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/retroactive_backfill.rs#L117) — `extract_entities()` is a heuristic tokenizer (tags + UPPER_SNAKE tokens + tokens containing `/` or `.`) returning `Vec<String>`
 
-3. **Dashboard as first-class surface.** Unlike many memory systems that are invisible, Vestige treats the 3D visualization as a core product feature, not an afterthought.
+It is computed per call and **never persisted**. There is no entity column and no entity table, and no extraction of people or packages. `CodeEntity`/`EntityType` ([`codebase/types.rs:440`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/codebase/types.rs#L440)) is unreachable from the MCP server. The definition requires entities "as separate fields or tables." Not met.
 
-4. **AGPL-3.0 license.** Network service provision requires open-sourcing modifications.
+### Actions ❌
+[`agent_traces`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L1079) has a dedicated `tool` column written on every MCP call, but arguments are FNV-1a hashed and never stored, and unified dispatchers mean the real operation lives in `args.mode`/`args.action` inside that hash. `tool` records `"memory"`, never `"promote"` vs `"demote"`. Not claimed.
 
-5. **No cloud dependency.** Model download is one-time. Everything afterward runs locally.
+### Keywords/tags ✅
+- [`crates/vestige-core/src/storage/migrations.rs:152`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L152) — `tags TEXT DEFAULT '[]'`, FTS5-indexed with sync triggers at `:174`
+- [`crates/vestige-mcp/src/tools/smart_ingest.rs:46`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/smart_ingest.rs#L46) — first-class ingest parameter
 
-## Evidence
+### Anticipated queries ❌
+HyDE ([`search/hyde.rs:79`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/search/hyde.rs#L79)) expands the *incoming query* at search time; variants are never persisted or bound to a node.
 
-`evidence: "https://github.com/carsteneu/ai-memory-comparison/blob/main/evidence/vestige.md"`
+### Trigger rules ✅ ← **was ❌**
+- [`crates/vestige-core/src/storage/migrations.rs:225`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L225) — `intentions` table with `trigger_type`, `trigger_data` JSON, and `deadline` columns
+- [`crates/vestige-core/src/neuroscience/prospective_memory.rs:261`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/neuroscience/prospective_memory.rs#L261) — `ContextPattern::FilePattern` / `InCodebase` / `TopicActive` / `UserMode`, evaluated by `IntentionTrigger::is_triggered(context, events)`
+- [`crates/vestige-mcp/src/tools/intention_unified.rs:39`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/intention_unified.rs#L39) — live `intention` tool schema exposing `file_pattern`, `codebase`, `topic`, `condition`
+- [`crates/vestige-mcp/src/server.rs:303`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L303) — registered; dispatched at [`:556`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L556)
+
+This is the definition's own example ("show this when file X is opened") plus deadlines, persisted and evaluated.
+
+### Domain tag ❌
+Columns exist but the production INSERT hardcodes `domains`/`domain_scores` to the string literals `'[]'` and `'{}'` ([`sqlite.rs:707`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L707)). No domain vocabulary exists.
+
+### Task type ❌
+`IntentionStatus` is a lifecycle, not a type. The closest match, `WorkStatus`, belongs to `WorkContext`, which is never constructed.
+
+### Context (why) ❌
+No "why" column exists. `build_and_save_receipt` has zero callers repo-wide, so `memory_receipts` is never populated.
+
+### Source attribution ❌
+`WriteSource` has 4 levels, but every production emit site hardcodes `Agent` ([`trace_recorder.rs:141`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/trace_recorder.rs#L141)); `Dream`/`Connector` appear only in unit tests. Fewer than 3 distinct levels in practice. Not claimed.
+
+### Origin + trust ❌
+Trust is derived from FSRS state, not capture method. The only capture-method-sensitive logic lives in `classify_write`, whose sole callers are its own `#[cfg(test)]` tests.
+
+### Emotional ❌
+`EmotionalMemory` ([`neuroscience/emotional_memory.rs:140`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/neuroscience/emotional_memory.rs#L140)) is consumed only by `DreamEngine`, which has no production callers. Live ingest hardcodes `sentiment_score: 0.0`; `emotional_valence` appears in exactly one code site, a `row.get()` read, and is never written.
+
+### Conflict surfacing ✅ ← **was ❌**
+- [`crates/vestige-mcp/src/tools/contradictions.rs:105`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/contradictions.rs#L105) — pairwise detector gated on topic overlap ≥ 0.4, winner decided by higher FSRS trust
+- [`crates/vestige-core/src/advanced/prediction_error.rs:549`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/prediction_error.rs#L549) — `detect_contradiction` runs at write time inside the `smart_ingest` gate
+- [`crates/vestige-mcp/src/server.rs:282`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L282) — `recall(mode='contradictions')` registered; surfaced at `/api/contradictions`
+
+*Stated plainly:* detection is lexical (negation and correction word pairs), not NLI.
+
+### Layered memory ❌
+`temporal_level` has no writer anywhere. The only non-NULL `summary_parent_id` write is inside `#[cfg(test)]`. `compressed_memories` was dropped in migration V11.
+
+### Time-travel ❌
+Supersede is invalidate-don't-delete, so old versions remain retrievable — but `query_at_time` has zero callers and `RecallInput.valid_at` is ignored by `Storage::recall`. No as-of query is reachable. Not claimed.
+
+### Schema fields (count: 27) ✅
+- [`crates/vestige-core/src/memory/node.rs:180-285`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/memory/node.rs#L180-L285) — `KnowledgeNode` has **31 fields**; 27 after excluding the 4 auto fields (`id`, `created_at`, `updated_at`, `last_accessed`)
+
+```
+content, node_type, stability, difficulty, reps, lapses, storage_strength,
+retrieval_strength, retention_strength, sentiment_score, sentiment_magnitude,
+next_review, source, tags, valid_from, valid_until, utility_score,
+times_retrieved, times_useful, emotional_valence, flashbulb, temporal_level,
+has_embedding, embedding_model, suppression_count, suppressed_at, source_envelope
+```
+
+The current entry lists 5. Counting only fields with a live production writer still gives roughly 20.
+
+---
+
+## Search & Retrieval
+
+### Full-text ✅
+- [`crates/vestige-core/src/storage/migrations.rs:174`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L174) — `CREATE VIRTUAL TABLE ... knowledge_fts USING fts5(...)`, queried with `MATCH ... ORDER BY rank` (BM25)
+
+### Semantic/vector ✅
+- [`crates/vestige-core/src/search/vector.rs:98`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/search/vector.rs#L98) — USearch HNSW, `MetricKind::Cos`
+
+### Hybrid (BM25+Vec) ✅
+- [`crates/vestige-core/src/storage/sqlite.rs:2970`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L2970) — `reciprocal_rank_fusion(&keyword_results, &semantic_results, 60.0)`, RRF k=60
+
+### Deep (incl. thinking) ❌ ← **was ✅ (corrected down)**
+- [`crates/vestige-core/src/trace/mod.rs:78`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/trace/mod.rs#L78) — MCP call args are stored as `args_hash` "so traces never leak prompt contents or secrets"
+- [`crates/vestige-core/src/storage/trace_store.rs:159`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/trace_store.rs#L159) — the trace store exposes `get_trace(run_id)` and `list_agent_runs` and **no search function**
+
+No model thinking or reasoning trace is stored anywhere; a repo-wide grep for `thinking_trace`/`reasoning_trace`/`chain_of_thought` returns zero hits. `recall(mode='reason')` is deep reasoning *over memories*, which is not what this column measures. The v2.1.23 audit reasonably read `deep_reference`'s 8-stage pipeline as satisfying this; on source it does not.
+
+### Code graph ❌
+`codebase/relationships.rs` is a file-path co-edit graph, not code structure. `RelationshipSource::AstAnalysis` is a dead enum variant with zero constructors, the only code "parsing" is `line.starts_with("pub fn ")`, and there is no `tree-sitter` or `syn` dependency.
+
+### Docs search ❌
+The only connectors are GitHub Issues and Redmine issues ([`tools/source_sync.rs:35`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/source_sync.rs#L35)). No documentation ingestion.
+
+### Fact metadata query ❌
+Three query-free structured surfaces exist (`codebase get_context`, `memory_status view='timeline'`, `intention list`), but the main search tool's `query` field is non-optional, so metadata-only queries are not generally available. Not claimed.
+
+### Timeline view ✅
+- [`crates/vestige-mcp/src/tools/timeline.rs:17`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/timeline.rs#L17) — ISO-8601 `start`/`end` range, `node_type`, `tags`, grouped by day
+
+### Search modes (count: 8) ✅
+`recall` lookup / `recall` concrete-literal / `recall` reason / `recall` contradictions / `memory_status` timeline / `memory_status` changelog / `graph` associations / `graph` predict — registered at [`server.rs:254`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L254) and [`:341`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L341). Current entry says 4.
+
+### Data sources (count: 3) ✅
+Memories/learnings; issue-tracker records (GitHub Issues with folded comment threads, Redmine issues and journals — [`connectors/github.rs:312`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/connectors/github.rs#L312)); codebase patterns and decisions. Connectors ship on by default ([`release.yml:41`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/.github/workflows/release.yml#L41)). Current entry says 1.
+
+---
+
+## Knowledge Lifecycle
+
+### Decay/forgetting ✅
+- [`crates/vestige-core/src/storage/sqlite.rs:3513`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L3513) — `apply_decay()` rewrites retrieval/retention strength from the FSRS-6 retrievability curve, in an unattended 6-hour loop
+
+### Supersede/replace ✅
+- [`crates/vestige-core/src/storage/migrations.rs:789`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L789) — `superseded_by` column + index (bitemporal: the old node stays queryable, stamped `valid_until`)
+- [`crates/vestige-core/src/storage/sqlite.rs:8384`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L8384) — previewable `plan_supersede` → `apply_plan` → reversible undo log
+
+### Contradiction detect ✅
+- [`crates/vestige-core/src/advanced/prediction_error.rs:364`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/prediction_error.rs#L364) — every non-forced ingest embeds the new content, pulls top-k similar memories, and runs `detect_contradiction` on each pair
+
+Rule-based (8 negation pairs, 9 correction phrases), not an NLI model.
+
+### Quarantine ❌
+`suppress` is a ranking penalty capped at 80% ([`active_forgetting.rs:38`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/neuroscience/active_forgetting.rs#L38)), not exclusion — suppressed memories still return from search. The `ReviewMode::Quarantine` firewall exists but `gate_writes` has zero production callers. No session scoping exists.
+
+### Auto-resolution ❌
+`auto_expire` exists only on the in-process map; persisted intentions are never registered with it, so the poller checks an empty map.
+
+### Trust model ❌ ← **was ✅ (corrected down)**
+- [`crates/vestige-mcp/src/tools/cross_reference.rs:62`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/cross_reference.rs#L62) — `compute_trust` is a single derived float: `0.4·retention + 0.2·min(stability/30,1) + 0.2·min(reps/10,1) + 0.2·(1−lapses/5)`
+
+That is FSRS state, not provenance. The `WriteSource` hierarchy that would make this a multi-tier source model is hardcoded to `Agent` at every production site. The only live tier is the user `protected` pin.
+
+### Explicit forget ✅
+- [`crates/vestige-mcp/src/tools/memory_unified.rs:46`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/memory_unified.rs#L46) — `memory action='purge'|'delete'` requiring `confirm=true`
+- [`crates/vestige-core/src/storage/sqlite.rs:2333`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L2333) — `purge_node` removes content **and** embeddings, retaining only a content-free tombstone
+
+---
+
+## Extraction Pipeline
+
+### Auto-extraction ❌ ← **was ✅ (corrected down)**
+Every write path is an explicitly invoked MCP tool ([`server.rs:564`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L564)). A repo-wide grep for `transcript`, `auto_capture`, `auto_ingest`, and `session_end` returns zero hits in `crates/`.
+
+`smart_ingest` enriches what it is handed (importance scoring, intent tagging, prediction-error routing), but an agent must call it. The definition's load-bearing clause is "without manual `save` calls," and Vestige is a manual-save system with a smart gate behind it.
+
+### Content-aware preprocessing ❌
+`preprocess_code`/`_error_log`/`_structured` are fully implemented at [`adaptive_embedding.rs:532`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/adaptive_embedding.rs#L532) but have no production caller; `smart_ingest` calls `ContentType::detect` and discards the result into `_content_type`.
+
+### Deduplication ✅
+- [`crates/vestige-core/src/storage/sqlite.rs:4066`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L4066) — `auto_dedup_consolidation` clusters at cosine ≥ 0.85 and merges automatically each cycle
+- [`crates/vestige-mcp/src/tools/dedup.rs:173`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/dedup.rs#L173) — manual `scan`/`plan_merge`/`apply`/`undo` with union-find clustering
+
+### Quality refinement ❌
+An ingest-time confidence composite and contradiction check exist, but there is no distinct post-extraction refinement pass. Not claimed.
+
+### Narrative generation ❌
+`MemoryCompressor::generate_summary` runs in consolidation step 9, but its result is bound to `if let Some(_compressed)` at [`sqlite.rs:3909`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L3909) and discarded. Nothing is persisted or surfaced.
+
+### Clustering ❌
+`dedup scan` and `MemoryDreamer::find_clusters` both group by embedding similarity, but there is no topic-cluster model or browsable cluster surface. Not claimed.
+
+### Recurrence detection ❌
+Tag-count heuristics only, with no session model or same-bug identity matching.
+
+### Persona extraction ❌
+The only occurrence of "persona" in `crates/` is a string in a sensitive-topics gating list.
+
+---
+
+## Platform Support
+
+### Claude Code ✅
+- [`docs/CONFIGURATION.md:209`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/CONFIGURATION.md#L209) — `claude mcp add vestige vestige-mcp -s user`
+- [`docs/CLAUDE-SETUP.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/CLAUDE-SETUP.md) — dedicated protocol doc, plus a hook harness under `hooks/`
+
+### Codex ✅
+- [`docs/integrations/codex.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/codex.md) — dedicated page; `codex mcp add vestige -- vestige-mcp`
+
+### OpenCode ✅ ← **was ❌**
+- [`docs/integrations/opencode.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/opencode.md) — dedicated page, "Verified with OpenCode 1.16.2 on June 8, 2026", documents the OpenCode-specific `mcp` config shape and warns that `mcpServers` does not work there
+- [`packages/vestige-init/bin/init.js:108`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/packages/vestige-init/bin/init.js#L108) — auto-detect/auto-install target
+
+### Gemini CLI ❌
+Zero occurrences tree-wide.
+
+### Copilot ❌
+[`docs/integrations/vscode.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/vscode.md) is titled "VS Code (GitHub Copilot)" and names Copilot in its prerequisites, setup path, and verification steps. Left ❌ because the column may mean Copilot outside VS Code — happy to take the maintainer's ruling either way.
+
+### Cursor ✅ ← **was ❌**
+- [`docs/integrations/cursor.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/cursor.md) — dedicated page with per-OS config paths and project-level `.cursor/mcp.json`
+
+### Windsurf ✅
+- [`docs/integrations/windsurf.md`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/windsurf.md) — dedicated page, per-OS `mcp_config.json` paths
+
+### OpenClaw ❌ / Hermes ❌ / pi-omp ❌ / Antigravity ❌
+Zero occurrences tree-wide for each. (The single "Hermes" hit is a `.gitignore` rule.)
+
+---
+
+## Benchmarks
+
+### LoCoMo ❌
+- Score: `—`
+
+### LongMemEval ❌
+- Score: `—`
+
+### PersonaMem ❌
+- Score: `—`
+
+### Token reduction ❌
+- Score: `—`
+
+### Methodology open ✅ ← **was ❌**
+- [`README.md:128-157`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/README.md#L128-L157) — the "Silent Rotation" experiment
+- Artifacts on the public branch [`benchmark/silent-rotation`](https://github.com/samvallad33/vestige/tree/f7606e65b11aad0dcf6bda682236caa63eed9358/benchmarks/silent-rotation) — `PREREGISTRATION.md`, `EVIDENCE.md`, `harness/` with 7 competitor arm runners (mem0, supermemory, zep, hindsight, rag, sync, anarchy), and 246 raw agent transcripts
+
+Pre-registered before results, with losing trials disclosed. The repro is stdlib-only and needs no network or API keys:
+
+```
+python3 tests/bm25_baseline.py results/runA-trial-1/corpus-export.json --no-dense
+```
+
+*Disclosure:* `benchmarks/` has **zero files on `main`** at the pinned SHA — the artifacts live on the `benchmark/silent-rotation` branch, which the README's clone command names explicitly. Flagging this rather than letting it read as a broken link.
+
+*Also disclosed:* an earlier "CauseBench" benchmark was **withdrawn and its numbers retracted** by the project ([`CHANGELOG.md:170-181`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/CHANGELOG.md#L170-L181)). Stale copies of those figures survive in two dead files under `docs/launch/`. They are not live claims and should not be credited to this project.
+
+---
+
+## Summary of changes
+
+**Upgraded (8):** `cacheOpt`, `scheduledExec`, `export`, `triggerRules`, `conflict`, `p_opencode`, `p_cursor`, `b_methodology`
+
+**Corrected down (4):** `entities`, `deep`, `trustModel`, `autoExtract`
+
+**Counts corrected:** `schemaFields` 5 → 27, `searchModes` 4 → 8, `dataSources` 1 → 3
+
+Net effect on coverage: 21/60 → 25/60.

--- a/evidence/vestige.md
+++ b/evidence/vestige.md
@@ -55,6 +55,8 @@ Multiple MCP clients can share one `--data-dir`, but there is no agent identity 
 - [`crates/vestige-core/src/storage/sqlite.rs:2843`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L2843) — `get_query_embedding()` returns the cached vector on hit, `cache.put(...)` on miss, so repeated queries skip re-embedding
 - [`crates/vestige-core/Cargo.toml:156`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/Cargo.toml#L156) — dependency declared under the comment "LRU cache for query embeddings"
 
+*Definitional note, volunteered:* the evidence template's wording ("caches intermediate results — embeddings, search results") is satisfied plainly. `CRITERIA.md`'s wording leans toward prompt/token caching ("prompt cache optimization, context collapse prevention, token-saving"), which Vestige does not do. The two documents differ; happy to take your ruling under whichever governs.
+
 ### Procedural memory ❌
 `MemorySystem::Procedural` ([`memory/mod.rs:81`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/memory/mod.rs#L81)) is a memory-type classification. Nothing loads, interprets, or executes stored content. The definition requires execution at retrieval time. Not claimed.
 
@@ -147,7 +149,7 @@ times_retrieved, times_useful, emotional_valence, flashbulb, temporal_level,
 has_embedding, embedding_model, suppression_count, suppressed_at, source_envelope
 ```
 
-The current entry lists 5. Counting only fields with a live production writer still gives roughly 20.
+The current entry lists 5. `CRITERIA.md` asks for an "approximate count of distinct structured fields per memory entry", which is 27 as defined. If you prefer to count only fields with a live production writer, the number is ~20 — either way, 5 is off by 4-5x. Both counts offered; your rubric, your pick.
 
 ---
 
@@ -174,14 +176,20 @@ No model thinking or reasoning trace is stored anywhere; a repo-wide grep for `t
 ### Docs search ❌
 The only connectors are GitHub Issues and Redmine issues ([`tools/source_sync.rs:35`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/source_sync.rs#L35)). No documentation ingestion.
 
-### Fact metadata query ❌
-Three query-free structured surfaces exist (`codebase get_context`, `memory_status view='timeline'`, `intention list`), but the main search tool's `query` field is non-optional, so metadata-only queries are not generally available. Not claimed.
+### Fact metadata query ✅ ← **was ❌**
+> Structured queries on memory metadata (e.g. "all unfinished tasks in project X", "all decisions about Y").
+
+- [`crates/vestige-core/src/storage/sqlite.rs:2767`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L2767) — `get_nodes_by_type_and_tag(node_type, tag_filter, limit)`: a pure metadata query, no text query required
+- [`crates/vestige-mcp/src/tools/codebase_unified.rs:301`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/codebase_unified.rs#L301) — exposed live: `codebase(action='get_context')` returns all `pattern`/`decision` nodes for a codebase tag — literally the criterion's "all decisions about Y"
+- [`crates/vestige-mcp/src/tools/intention_unified.rs:129`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/intention_unified.rs#L129) — `intention(action='list', filter_status='active')` — literally "all unfinished tasks"
+
+*Scope stated plainly:* these are fixed structured surfaces, not a general metadata query language; the main search tool still requires a text query. Claimed because the criterion's own two examples are both directly satisfied.
 
 ### Timeline view ✅
 - [`crates/vestige-mcp/src/tools/timeline.rs:17`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/timeline.rs#L17) — ISO-8601 `start`/`end` range, `node_type`, `tags`, grouped by day
 
-### Search modes (count: 8) ✅
-`recall` lookup / `recall` concrete-literal / `recall` reason / `recall` contradictions / `memory_status` timeline / `memory_status` changelog / `graph` associations / `graph` predict — registered at [`server.rs:254`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L254) and [`:341`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L341). Current entry says 4.
+### Search modes (count: 7) ✅
+`recall` lookup / `recall` reason / `recall` contradictions / `memory_status` timeline / `memory_status` changelog / `graph` associations / `graph` predict. (The auto-detected literal/exact routing inside `recall` is deliberately **not** counted as an eighth mode: it is a parameter, not a distinct tool.) — registered at [`server.rs:254`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L254) and [`:341`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/server.rs#L341). Current entry says 4.
 
 ### Data sources (count: 3) ✅
 Memories/learnings; issue-tracker records (GitHub Issues with folded comment threads, Redmine issues and journals — [`connectors/github.rs:312`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/connectors/github.rs#L312)); codebase patterns and decisions. Connectors ship on by default ([`release.yml:41`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/.github/workflows/release.yml#L41)). Current entry says 1.
@@ -233,14 +241,27 @@ Every write path is an explicitly invoked MCP tool ([`server.rs:564`](https://gi
 - [`crates/vestige-core/src/storage/sqlite.rs:4066`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L4066) — `auto_dedup_consolidation` clusters at cosine ≥ 0.85 and merges automatically each cycle
 - [`crates/vestige-mcp/src/tools/dedup.rs:173`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/dedup.rs#L173) — manual `scan`/`plan_merge`/`apply`/`undo` with union-find clustering
 
-### Quality refinement ❌
-An ingest-time confidence composite and contradiction check exist, but there is no distinct post-extraction refinement pass. Not claimed.
+### Quality refinement ✅ ← **was ❌**
+> LLM-based or rule-based quality pass after initial extraction (confidence scoring, contradiction check).
+
+Rule-based, exactly the criterion's parenthetical:
+
+- [`crates/vestige-mcp/src/tools/smart_ingest.rs:186`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/smart_ingest.rs#L186) — 4-channel importance/confidence composite computed for every ingest
+- [`crates/vestige-core/src/advanced/prediction_error.rs:364`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/prediction_error.rs#L364) — contradiction check against top-k similar memories inside the same gate, rerouting create → update/supersede/merge
+- [`crates/vestige-core/src/advanced/dreams.rs:1541`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/dreams.rs#L1541) — post-hoc: consolidation-generated insights are dropped unless `novelty_score >= config.min_novelty` and confidence passes
+
+No LLM is involved; the criterion explicitly allows rule-based.
 
 ### Narrative generation ❌
 `MemoryCompressor::generate_summary` runs in consolidation step 9, but its result is bound to `if let Some(_compressed)` at [`sqlite.rs:3909`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L3909) and discarded. Nothing is persisted or surfaced.
 
-### Clustering ❌
-`dedup scan` and `MemoryDreamer::find_clusters` both group by embedding similarity, but there is no topic-cluster model or browsable cluster surface. Not claimed.
+### Clustering ✅ ← **was ❌**
+> Groups related memories by topic, embedding similarity, or semantic relationship.
+
+- [`crates/vestige-core/src/advanced/dreams.rs:1456`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/advanced/dreams.rs#L1456) — `find_clusters`: connected components over discovered connections (embedding cosine when available, else tag/word Jaccard), running unattended in consolidation step 8 ([`sqlite.rs:3702`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L3702)); cluster membership persists via `insights.source_memories`
+- [`crates/vestige-mcp/src/tools/dedup.rs:173`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/dedup.rs#L173) — on-demand union-find clusters at cosine ≥ threshold
+
+"Embedding similarity" grouping is the criterion's own wording. There is no *topic model*; the criterion does not require one.
 
 ### Recurrence detection ❌
 Tag-count heuristics only, with no session model or same-bug identity matching.
@@ -312,10 +333,10 @@ python3 tests/bm25_baseline.py results/runA-trial-1/corpus-export.json --no-dens
 
 ## Summary of changes
 
-**Upgraded (8):** `cacheOpt`, `scheduledExec`, `export`, `triggerRules`, `conflict`, `p_opencode`, `p_cursor`, `b_methodology`
+**Upgraded (11):** `cacheOpt`, `scheduledExec`, `export`, `triggerRules`, `conflict`, `factQuery`, `qualityRefine`, `clustering`, `p_opencode`, `p_cursor`, `b_methodology`
 
 **Corrected down (4):** `entities`, `deep`, `trustModel`, `autoExtract`
 
-**Counts corrected:** `schemaFields` 5 → 27, `searchModes` 4 → 8, `dataSources` 1 → 3
+**Counts corrected:** `schemaFields` 5 → 27, `searchModes` 4 → 7, `dataSources` 1 → 3
 
-Net effect on coverage: 21/60 → 25/60.
+Net effect on coverage: 21/60 → 28/60.


### PR DESCRIPTION
Maintainer of [Vestige](https://github.com/samvallad33/vestige) here.

First, thank you for the 2026-05-28 audit. It corrected eleven cells in Vestige's favour unprompted and fixed a repo URL that pointed at a 404. That was more care than I had any right to expect.

That audit was explicit about its own scope. It says *"the following features are genuinely not mentioned anywhere in the README"* and titles its inventory *"Feature Inventory (from README)."* Since CONTRIBUTING says **"Code beats docs,"** this PR does the source-level pass, at a pinned commit so the line numbers never rot.

**I am correcting four cells DOWN.** They did not survive your own definitions, and I would rather find them than have someone else find them after the number moves.

### Corrected down

| cell | why it fails the definition |
|---|---|
| `entities` | `extract_entities()` is a heuristic tokenizer computed per call and **never persisted**. No entity column, no entity table, no people or packages. |
| `deep` | Definition is "search includes model thinking/reasoning traces." Vestige hashes call args specifically so traces never store prompt contents, the trace store has **no search function**, and a repo-wide grep for thinking or reasoning trace identifiers returns zero. `deep_reference` is deep reasoning *over memories*, which is not this column. |
| `trustModel` | `compute_trust` is one FSRS-derived float. The `WriteSource` hierarchy that would make it multi-tier is hardcoded to `Agent` at every production site. |
| `autoExtract` | Every write path is an explicitly invoked MCP tool. Zero hits for `transcript`, `auto_capture`, `auto_ingest`, `session_end`. Vestige is a manual-save system with a smart gate behind it. |

### Upgraded

| cell | evidence |
|---|---|
| `export` | `vestige export <out> --format json\|jsonl` clap subcommand, [cli.rs#L158](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/bin/cli.rs#L158) |
| `cacheOpt` | `LruCache<String, Vec<f32>>` query-embedding cache, [sqlite.rs#L318](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/sqlite.rs#L318) |
| `scheduledExec` | 60s autopilot poller + autonomous promotion, on by default, [autopilot.rs#L461](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/autopilot.rs#L461) |
| `triggerRules` | `intentions` table with `trigger_type`/`trigger_data`/`deadline`, [migrations.rs#L225](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/storage/migrations.rs#L225); live `file_pattern` tool schema |
| `conflict` | Read-time pairwise detector + write-time gate, [contradictions.rs#L105](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-mcp/src/tools/contradictions.rs#L105). Lexical, not NLI, and the file says so. |
| `p_opencode` | [Dedicated page](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/opencode.md), pins a verified client version and documents an OpenCode-only config shape |
| `p_cursor` | [Dedicated page](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/cursor.md), per-OS config paths |
| `b_methodology` | Pre-registered experiment with 7 competitor arms and 246 raw transcripts. Repro is stdlib-only, no network, no API keys. |

### Counts

`schemaFields` 5 to **27**. [`KnowledgeNode`](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/crates/vestige-core/src/memory/node.rs#L180-L285) has 31 fields, 27 after excluding the 4 auto ones. One struct, one screen.

`searchModes` 4 to 8. `dataSources` 1 to 3.

### Disclosures I would rather volunteer

- **The benchmark artifacts are not on `main`.** `benchmarks/` is empty at the pinned commit. Silent Rotation lives on the public `benchmark/silent-rotation` branch, which the README's clone command names. Flagging it so it does not read as a broken link.
- **An earlier benchmark was retracted.** A previous "CauseBench" was withdrawn and its numbers retracted by the project ([CHANGELOG#L170](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/CHANGELOG.md#L170-L181)). Stale copies survive in two dead files under `docs/launch/`. They are not live claims. Please do not credit them.
- **Two autonomous behaviours are env-gated but default on**, named in the evidence file.
- **`p_copilot` I left as ❌**, though [the VS Code page](https://github.com/samvallad33/vestige/blob/54f69b369ec478aefddfc72093bf06d0fc9d21a3/docs/integrations/vscode.md) is titled "VS Code (GitHub Copilot)" and names Copilot in its prerequisites, setup, and verification. If the column means Copilot-in-VS-Code it is arguably ✅. Your call, and I am fine either way.
- **Not claimed on purpose**, because they fail their definitions on inspection even though the feature names suggest otherwise: `proceduralMemory` (an enum variant, nothing executes), `codeGraph` (a file co-edit graph, no AST, and the AST enum variant has zero constructors), `quarantine`, `multiAgent`, `narrative`, `clustering`, `contentPreproc`.

### Verification

Every one of the 70 citations is a permalink pinned to `samvallad33/vestige@54f69b3` (v2.3.0). I ran a script that extracts each link, confirms the path exists at that commit, and confirms the cited line is in range. **70 resolved, 0 broken, 0 out of range.**

Net coverage 21/60 to 25/60. I have updated `comparison.md` and `evidence/vestige.md`, and left `data.js` for you to regenerate.
